### PR TITLE
Ability to specify proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The program can be invoked as follows:
                                Trust Black Duck server certificates if unsigned
          --blackduck_timeout   Change the server connection timeout (default 15 seconds)
          --debug               Add reporting of processed components
+         --proxy_url           Proxy configuration if you're behind a proxy. (Note: still neccessary to define proxy environment variables) 
 
 
 If `project_name` does not match a single project then all matching projects will be listed and the script will terminate.

--- a/export_spdx/config.py
+++ b/export_spdx/config.py
@@ -38,6 +38,7 @@ parser.add_argument("--blackduck_api_token", type=str,
 parser.add_argument("--blackduck_trust_certs", help="BLACKDUCK trust certs", action='store_true')
 parser.add_argument("--blackduck_timeout", help="BD Server requests timeout (seconds - default 15)", default=15)
 parser.add_argument("--debug", help="Turn on debug messages", action='store_true')
+parser.add_argument("--proxy_url", help="Proxy to use", type=str)
 
 args = parser.parse_args()
 

--- a/export_spdx/config.py
+++ b/export_spdx/config.py
@@ -38,7 +38,7 @@ parser.add_argument("--blackduck_api_token", type=str,
 parser.add_argument("--blackduck_trust_certs", help="BLACKDUCK trust certs", action='store_true')
 parser.add_argument("--blackduck_timeout", help="BD Server requests timeout (seconds - default 15)", default=15)
 parser.add_argument("--debug", help="Turn on debug messages", action='store_true')
-parser.add_argument("--proxy_url", help="Proxy to use", type=str)
+parser.add_argument("--proxy_url", help="Proxy to use", type=str, default="")
 
 args = parser.parse_args()
 

--- a/export_spdx/main.py
+++ b/export_spdx/main.py
@@ -38,6 +38,8 @@ if api == '' or api is None:
     print('BLACKDUCK_API_TOKEN not set or specified as option --blackduck_api_token')
     sys.exit(2)
 
+globals.proxy_url = config.args.proxy_url
+
 globals.bd = Client(
     token=api,
     base_url=url,

--- a/export_spdx/process.py
+++ b/export_spdx/process.py
@@ -428,7 +428,7 @@ async def async_get_copyrights(session, comp, token):
         'Authorization': f'Bearer {token}',
     }
     # resp = globals.bd.get_json(thishref, headers=headers)
-    async with session.get(thishref, headers=headers, ssl=ssl) as resp:
+    async with session.get(thishref, headers=headers, ssl=ssl, proxy=globals.proxy_url) as resp:
         result_data = await resp.json()
         for copyrt in result_data['items']:
             if copyrt['active']:
@@ -458,7 +458,7 @@ async def async_get_comments(session, comp, token):
             'accept': "application/vnd.blackducksoftware.bill-of-materials-6+json",
         }
         # resp = globals.bd.get_json(thishref, headers=headers)
-        async with session.get(thishref, headers=headers, ssl=ssl) as resp:
+        async with session.get(thishref, headers=headers, ssl=ssl, proxy=globals.proxy_url) as resp:
             result_data = await resp.json()
             mytime = datetime.datetime.now()
             # mytime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -491,7 +491,7 @@ async def async_get_files(session, comp, token):
             'accept': "application/vnd.blackducksoftware.bill-of-materials-6+json",
         }
 
-        async with session.get(thishref, headers=headers, ssl=ssl) as resp:
+        async with session.get(thishref, headers=headers, ssl=ssl, proxy=globals.proxy_url) as resp:
             result_data = await resp.json()
             cfile = result_data['items']
             if len(cfile) > 0:
@@ -538,7 +538,7 @@ async def async_get_licenses(session, lcomp, token):
                     }
                     # resp = globals.bd.session.get('/api/licenses/' + lic_ref + '/text', headers=headers)
                     thishref = f"{globals.bd.base_url}/api/licenses/{lic_ref}/text"
-                    async with session.get(thishref, headers=headers, ssl=ssl) as resp:
+                    async with session.get(thishref, headers=headers, ssl=ssl, proxy=globals.proxy_url) as resp:
                         # lic_text = await resp.content.decode("utf-8")
                         lic_text = await resp.text('utf-8')
                         if thislic not in globals.spdx_lics:
@@ -581,7 +581,7 @@ async def async_get_url(session, comp, token):
         'Authorization': f'Bearer {token}',
     }
     # resp = globals.bd.get_json(thishref, headers=headers)
-    async with session.get(link, headers=headers, ssl=ssl) as resp:
+    async with session.get(link, headers=headers, ssl=ssl, proxy=globals.proxy_url) as resp:
         result_data = await resp.json()
         if 'url' in result_data.keys():
             url = result_data['url']
@@ -605,7 +605,7 @@ async def async_get_supplier(session, comp, token):
             'accept': "application/vnd.blackducksoftware.bill-of-materials-6+json",
         }
 
-        async with session.get(thishref, headers=headers, ssl=ssl) as resp:
+        async with session.get(thishref, headers=headers, ssl=ssl, proxy=globals.proxy_url) as resp:
             result_data = await resp.json()
             cfields = result_data['items']
             sbom_field = next((item for item in cfields if item['label'] == globals.SBOM_CUSTOM_SUPPLIER_NAME),

--- a/export_spdx/process.py
+++ b/export_spdx/process.py
@@ -357,7 +357,7 @@ def process_project(project, version, projspdxname, hcomps, bearer_token, exclud
 
 
 async def async_main(compsdict, token, ver):
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         copyright_tasks = []
         comment_tasks = []
         file_tasks = []


### PR DESCRIPTION
Adding parameter --proxy_url to be able to use a proxy for the calls to blackduck. Note: It's still neccessary to define http_proxy,https_proxy as the authentication at Blackduck doesn't provide a ability to pass a proxy (would need to pass a special session object but unable to do that - no knowledge)